### PR TITLE
Fix fstab entry for nfs root devices

### DIFF
--- a/templates/fstab.j2
+++ b/templates/fstab.j2
@@ -2,14 +2,15 @@
 {% set fmtstr='%-50s%-20s%-8s%-17s%s' -%}
 {{ fmtstr|format('# <filesystem>', '<mountpoint>', '<type>', '<options>', '<dump/pass>') }}
 
-{% set mount_options='remount,rw' -%}
-{%- if vm.storage_type|default(xen_vman_default_storage_type) == "iscsi" -%}
+{% if vm.storage_type|default(xen_vman_default_storage_type) == "iscsi" -%}
 	{%- set root_device='/dev/xvda' -%}
 	{%- set filesystem=vm.filesystem|default(xen_vman_default_filesystem) -%}
+	{%- set mount_options='remount,rw' -%}
 	{%- set pass_str='0 1' -%}
 {%- elif vm.storage_type|default(xen_vman_default_storage_type) == "nfs" -%}
 	{%- set root_device='%s%s/%s-root'|format(xen_vman_nfsroot_base, vm.org, vm.name) -%}
 	{%- set filesystem='nfs' -%}
+	{%- set mount_options='_netdev' -%}
 	{%- set pass_str='0 0' -%}
 {%- endif %}
 


### PR DESCRIPTION
_netdev seems to be the correct mount option for nfs devices