### PR TITLE
Revert "tasks/systemd.yml: Validate unit files"

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -6,7 +6,6 @@
     owner: root
     mode: 0644
     src: vm@.service.j2
-    validate: systemd-analyze verify %s
   notify: Reload systemd daemon
 
 - name: Install systemd service file (vm_iscsi@.service)
@@ -16,7 +15,6 @@
     owner: root
     mode: 0644
     src: vm_iscsi@.service.j2
-    validate: systemd-analyze verify %s
   notify: Reload systemd daemon
   when: xen_vman_iscsi_base_wwn is defined and xen_vman_iscsi_server is defined
 
@@ -52,5 +50,4 @@
     owner: root
     mode: 0644
     src: vm_mount@.service.j2
-    validate: systemd-analyze verify %s
   notify: Reload systemd daemon


### PR DESCRIPTION

Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232