### PR TITLE
feat(vif-p2p): Use link-local IPv6 as nexthop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,20 +101,21 @@ The exported path for the root filesystem must be of the following scheme:
 This role currently supports a custom network script called `vif-p2p`.
 It is like (the official) `vif-route`, except that it configures the vif
 interface using a P2P configuration from dom0 to the guest.
-That is, if `vif-route` configures the interface like so:
+
+`vif-p2p` supports IPv6.
+To use this IPv6 feature, you must yourself configure your VMs to use the link-local address `fe80::2/64` and gateway `fe80::1` on `eth0`.
+Those link-local addresses are fixed and are the same for all VMs.
+
+That is, `vif-p2p` automatically configures the interface on the host like
 
 ```bash
-ip address add 10.0.0.1/32 dev vif10.0
-ip route add 10.0.0.5/32 dev vif10.0 src 10.0.0.1
+ip address add 10.0.0.1/32 peer 10.0.0.10 dev vif10.0
+ip address add fe80::1/64 dev vif10.0
+ip route add 2001:DB8::10/128 via fe80::2 dev vif10.0
 ```
 
-Then `vif-p2p` configures the interface like so instead:
-
-```bash
-ip address add 10.0.0.1/32 peer 10.0.0.5 dev vif10.0
-```
-
-This way, the kernel will automatically add the necessary route.
+if `10.0.0.1` is the main IP of the hypervisor, `10.0.0.10` is the `ip` of the first [VM interface](#vm-interfaces) and `2001:DB8::10` is the `ipv6` of the first [VM interface](#vm-interfaces).
+(For IPv4, the kernel will automatically add the necessary route.)
 
 In order to install `vif-p2p` you have to add the string `"vif-p2p"` to
 `xen_vman_additional_network_scripts`.

--- a/files/vif-p2p
+++ b/files/vif-p2p
@@ -29,7 +29,7 @@ case "${command}" in
         for addr in ${ip} ; do
             if [[ $addr =~ .*:.* ]]; then
                 # IPv6
-                ip route add ${addr} dev ${dev}
+                ip route add ${addr} via fe80::2 dev ${dev}
             else
                 # IPv4
                 ip address add ${main_ip} peer ${addr} dev ${dev}


### PR DESCRIPTION
Apparently, in IPv6 it's problematic to have a directly attached prefix if the localhost has no IP in that prefix, as it is the case when directly attaching a /128, i.e., a single IP. The symptom we encountered is: When configuring bird6 to statically route another prefix via that single IP, bird6 doesn't install the route and instead complains that that IP (from the /128) is a "strange next-hop".

Therefore, we instead of directly attaching the /128, we use the link-local address of the VM as a hop. This requires to fix the link-local address of the VM, as documented in `README.md`.